### PR TITLE
Added ServicePackageActivationId to API to differentiate CodePackage from same service on a single node

### DIFF
--- a/src/Sfx/App/Scripts/Common/RestClient.ts
+++ b/src/Sfx/App/Scripts/Common/RestClient.ts
@@ -220,7 +220,7 @@ module Sfx {
             return this.get(formedUrl, "Get deployed code package", messageHandler);
         }
 
-        public getDeployedContainerLogs(nodeName: string, applicationId: string, servicePackageName: string, codePackageName: string, tail: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<IRawContainerLogs> {
+        public getDeployedContainerLogs(nodeName: string, applicationId: string, servicePackageName: string, codePackageName: string, servicePackageActivationId: string, tail: string, messageHandler?: IResponseMessageHandler): angular.IHttpPromise<IRawContainerLogs> {
             let url = "Nodes/" + encodeURIComponent(nodeName)
                 + "/$/GetApplications/" + encodeURIComponent(applicationId)
                 + "/$/GetCodePackages"
@@ -229,6 +229,7 @@ module Sfx {
             let formedUrl = this.getApiUrl(url)
                 + "&ServiceManifestName=" + encodeURIComponent(servicePackageName)
                 + "&CodePackageName=" + encodeURIComponent(codePackageName)
+                + "&ServicePackageActivationId=" + encodeURIComponent(servicePackageActivationId)
                 + "&Tail=" + encodeURIComponent(tail);
 
             return this.get(formedUrl, "Get deployed container logs", messageHandler);

--- a/src/Sfx/App/Scripts/Models/DataModels/DeployedCodePackage.ts
+++ b/src/Sfx/App/Scripts/Models/DataModels/DeployedCodePackage.ts
@@ -112,7 +112,7 @@ module Sfx {
         protected retrieveNewData(messageHandler?: IResponseMessageHandler): angular.IPromise<IRawContainerLogs> {
             let deployedCodePackage = <DeployedCodePackage>(this.parent);
             return Utils.getHttpResponseData(
-                this.data.restClient.getDeployedContainerLogs(deployedCodePackage.parent.parent.parent.name, deployedCodePackage.parent.parent.id, deployedCodePackage.parent.name, deployedCodePackage.name, deployedCodePackage.containerLogsTail, messageHandler));
+                this.data.restClient.getDeployedContainerLogs(deployedCodePackage.parent.parent.parent.name, deployedCodePackage.parent.parent.id, deployedCodePackage.parent.name, deployedCodePackage.name, deployedCodePackage.servicePackageActivationId, deployedCodePackage.containerLogsTail, messageHandler));
         }
     }
 }


### PR DESCRIPTION
Container logs query doesn’t work if there is more than one service of the same service type belonging to the same application on that node
Added ServicePackageActivationId to API to differentiate CodePackage from same service on a single node